### PR TITLE
Remove ascii-superset dependency

### DIFF
--- a/redis-glob.cabal
+++ b/redis-glob.cabal
@@ -36,8 +36,7 @@ library
   default-language: Haskell2010
   ghc-options:      -Wall -Wincomplete-uni-patterns -fwarn-tabs
   build-depends:
-    , ascii-char      >=1.0      && <1.3
-    , ascii-superset  >=1.0      && <1.3
+    , ascii-char      >=1.0.1    && <1.1
     , base            >=4.11     && <5.0
     , bytestring      >=0.10.8.2 && <0.11 || >=0.11.3.1 && <0.12
     , megaparsec      >=9.2.1    && <9.4

--- a/src/Redis/Glob/Internal.hs
+++ b/src/Redis/Glob/Internal.hs
@@ -32,7 +32,6 @@ module Redis.Glob.Internal (
 ) where
 
 import qualified ASCII.Char as A
-import qualified ASCII.Superset as A
 import Data.ByteString.Builder (Builder, toLazyByteString, word8)
 import Data.ByteString.Lazy (ByteString)
 import Data.Functor (($>))
@@ -266,10 +265,10 @@ inSquare inside = word8 leftSquare <> inside <> word8 rightSquare
 
 
 hat, qmark, star, leftSquare, rightSquare, dash, backslash :: Word8
-hat = A.fromChar A.Caret
-qmark = A.fromChar A.QuestionMark
-star = A.fromChar A.Asterisk
-leftSquare = A.fromChar A.LeftSquareBracket
-rightSquare = A.fromChar A.RightSquareBracket
-dash = A.fromChar A.HyphenMinus
-backslash = A.fromChar A.Backslash
+hat = A.toWord8 A.Caret
+qmark = A.toWord8 A.QuestionMark
+star = A.toWord8 A.Asterisk
+leftSquare = A.toWord8 A.LeftSquareBracket
+rightSquare = A.toWord8 A.RightSquareBracket
+dash = A.toWord8 A.HyphenMinus
+backslash = A.toWord8 A.Backslash


### PR DESCRIPTION
Hi, thanks for using the ascii library! This was the first time I've ever pushed a release that prompted a Stackage issue :smile: I was interested to see how it was being used, so I took a look at `redis-glob`. I see the only thing you needed `ascii-superset` for was conversion to `Word8`. This seems like a simple and common enough task that it should just get incorporated into the much smaller `ascii-char` package. I've published that as `ascii-char-1.0.1.0`, so can now reduce your dependency set a bit if you raise the `ascii-char` lower bound to `1.0.1`.